### PR TITLE
fs2dt: Fix for parsing/reading entries > 4k

### DIFF
--- a/kexec/arch/ppc/fs2dt.c
+++ b/kexec/arch/ppc/fs2dt.c
@@ -180,6 +180,19 @@ static void add_usable_mem_property(int fd, int len)
 	dt += (rlen + 3)/4;
 }
 
+static int dt_read(int fd, void *dt, int len)
+{
+	int done = 0, len2;
+
+	while (len > 0 && (len2 = read(fd, dt, len)) > 0) {
+		len -= len2;
+		dt += len2;
+		done += len2;
+	}
+
+	return done;
+}
+
 /* put all properties (files) in the property structure */
 static void putprops(char *fn, struct dirent **nlist, int numlist)
 {
@@ -238,7 +251,7 @@ static void putprops(char *fn, struct dirent **nlist, int numlist)
 			die("unrecoverable error: could not open \"%s\": %s\n",
 			    pathname, strerror(errno));
 
-		if (read(fd, dt, len) != len)
+		if (dt_read(fd, dt, len) != len)
 			die("unrecoverable error: could not read \"%s\": %s\n",
 			    pathname, strerror(errno));
 


### PR DESCRIPTION
The device-tree only does 4k reads at a time, so for entries greater
than that, the fs2dt code would fail, assuming a single read would get
the whole item.

Added helper function to continue reading as long as there was data and
no errors.

This was evident from:

/proc/device-tree/soc@ffe000000/fman@400000/fman-firmware/fsl,firmware

On my P4080 system, which is 29668 bytes.

Signed-off-by: Ben Collins <ben@cyphre.com>