### PR TITLE
[PATCHv3 0/6] arm64: zboot support

### DIFF
--- a/include/kexec-pe-zboot.h
+++ b/include/kexec-pe-zboot.h
@@ -1,0 +1,15 @@
+#ifndef __KEXEC_PE_ZBOOT_H__
+#define __KEXEC_PE_ZBOOT_H__
+
+/* see drivers/firmware/efi/libstub/zboot-header.S */
+struct linux_pe_zboot_header {
+	uint32_t mz_magic;
+        uint32_t image_type;
+        uint32_t payload_offset;
+        uint32_t payload_size;
+        uint32_t reserved[2];
+        uint32_t compress_type;
+};
+
+int pez_prepare(const char *crude_buf, off_t kernel_size, struct kexec_info *info);
+#endif

--- a/kexec/Makefile
+++ b/kexec/Makefile
@@ -17,6 +17,7 @@ KEXEC_SRCS_base += kexec/kexec-elf-exec.c
 KEXEC_SRCS_base += kexec/kexec-elf-core.c
 KEXEC_SRCS_base += kexec/kexec-elf-rel.c
 KEXEC_SRCS_base += kexec/kexec-elf-boot.c
+KEXEC_SRCS_base += kexec/kexec-pe-zboot.c
 KEXEC_SRCS_base += kexec/kexec-iomem.c
 KEXEC_SRCS_base += kexec/firmware_memmap.c
 KEXEC_SRCS_base += kexec/crashdump.c

--- a/kexec/arch/arm/kexec-arm.h
+++ b/kexec/arch/arm/kexec-arm.h
@@ -9,12 +9,14 @@
 
 extern off_t initrd_base, initrd_size;
 
-int zImage_arm_probe(const char *buf, off_t len);
+int zImage_arm_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int zImage_arm_load(int argc, char **argv, const char *buf, off_t len,
 		        struct kexec_info *info);
 void zImage_arm_usage(void);
 
-int uImage_arm_probe(const char *buf, off_t len);
+int uImage_arm_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int uImage_arm_load(int argc, char **argv, const char *buf, off_t len,
 		        struct kexec_info *info);
 extern int have_sysfs_fdt(void);

--- a/kexec/arch/arm/kexec-uImage-arm.c
+++ b/kexec/arch/arm/kexec-uImage-arm.c
@@ -9,7 +9,7 @@
 #include "../../kexec.h"
 #include "kexec-arm.h"
 
-int uImage_arm_probe(const char *buf, off_t len)
+int uImage_arm_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	return uImage_probe_kernel(buf, len, IH_ARCH_ARM);
 }

--- a/kexec/arch/arm/kexec-zImage-arm.c
+++ b/kexec/arch/arm/kexec-zImage-arm.c
@@ -135,7 +135,7 @@ struct zimage_tag {
 	} u;
 };
 
-int zImage_arm_probe(const char *UNUSED(buf), off_t UNUSED(len))
+int zImage_arm_probe(const char *UNUSED(buf), off_t UNUSED(len), struct kexec_info *UNUSED(info))
 {
 	/* 
 	 * Only zImage loading is supported. Do not check if

--- a/kexec/arch/arm64/Makefile
+++ b/kexec/arch/arm64/Makefile
@@ -16,7 +16,8 @@ arm64_KEXEC_SRCS += \
 	kexec/arch/arm64/kexec-elf-arm64.c \
 	kexec/arch/arm64/kexec-uImage-arm64.c \
 	kexec/arch/arm64/kexec-image-arm64.c \
-	kexec/arch/arm64/kexec-zImage-arm64.c
+	kexec/arch/arm64/kexec-zImage-arm64.c \
+	kexec/arch/arm64/kexec-vmlinuz-arm64.c
 
 arm64_UIMAGE = kexec/kexec-uImage.c
 

--- a/kexec/arch/arm64/image-header.h
+++ b/kexec/arch/arm64/image-header.h
@@ -37,6 +37,7 @@ struct arm64_image_header {
 
 static const uint8_t arm64_image_magic[4] = {'A', 'R', 'M', 0x64U};
 static const uint8_t arm64_image_pe_sig[2] = {'M', 'Z'};
+static const uint8_t arm64_pe_machtype[6] = {'P','E', 0x0, 0x0, 0x64, 0xAA};
 static const uint64_t arm64_image_flag_be = (1UL << 0);
 static const uint64_t arm64_image_flag_page_size = (3UL << 1);
 static const uint64_t arm64_image_flag_placement = (1UL << 3);

--- a/kexec/arch/arm64/kexec-arm64.c
+++ b/kexec/arch/arm64/kexec-arm64.c
@@ -75,6 +75,7 @@ struct file_type file_type[] = {
 	{"Image", image_arm64_probe, image_arm64_load, image_arm64_usage},
 	{"uImage", uImage_arm64_probe, uImage_arm64_load, uImage_arm64_usage},
 	{"zImage", zImage_arm64_probe, zImage_arm64_load, zImage_arm64_usage},
+	{"vmlinuz", pez_arm64_probe, image_arm64_load, pez_arm64_usage},
 };
 
 int file_types = sizeof(file_type) / sizeof(file_type[0]);

--- a/kexec/arch/arm64/kexec-arm64.h
+++ b/kexec/arch/arm64/kexec-arm64.h
@@ -29,14 +29,14 @@
 #define NOT_KV_ADDR	(0x0)
 #define NOT_PADDR	(ULONGLONG_MAX)
 
-int elf_arm64_probe(const char *kernel_buf, off_t kernel_size,
+int elf_arm64_probe(const char *kern_fname, off_t kernel_size,
 		    struct kexec_info *info);
 
 int elf_arm64_load(int argc, char **argv, const char *kernel_buf,
 	off_t kernel_size, struct kexec_info *info);
 void elf_arm64_usage(void);
 
-int image_arm64_probe(const char *kernel_buf, off_t kernel_size,
+int image_arm64_probe(const char *kern_fname, off_t kernel_size,
 		      struct kexec_info *info);
 
 int image_arm64_load(int argc, char **argv, const char *kernel_buf,
@@ -49,7 +49,7 @@ int uImage_arm64_load(int argc, char **argv, const char *buf, off_t len,
 		      struct kexec_info *info);
 void uImage_arm64_usage(void);
 
-int zImage_arm64_probe(const char *kernel_buf, off_t kernel_size,
+int zImage_arm64_probe(const char *kern_fname, off_t kernel_size,
 		       struct kexec_info *info);
 
 int zImage_arm64_load(int argc, char **argv, const char *kernel_buf,

--- a/kexec/arch/arm64/kexec-arm64.h
+++ b/kexec/arch/arm64/kexec-arm64.h
@@ -29,22 +29,29 @@
 #define NOT_KV_ADDR	(0x0)
 #define NOT_PADDR	(ULONGLONG_MAX)
 
-int elf_arm64_probe(const char *kernel_buf, off_t kernel_size);
+int elf_arm64_probe(const char *kernel_buf, off_t kernel_size,
+		    struct kexec_info *info);
+
 int elf_arm64_load(int argc, char **argv, const char *kernel_buf,
 	off_t kernel_size, struct kexec_info *info);
 void elf_arm64_usage(void);
 
-int image_arm64_probe(const char *kernel_buf, off_t kernel_size);
+int image_arm64_probe(const char *kernel_buf, off_t kernel_size,
+		      struct kexec_info *info);
+
 int image_arm64_load(int argc, char **argv, const char *kernel_buf,
 	off_t kernel_size, struct kexec_info *info);
 void image_arm64_usage(void);
 
-int uImage_arm64_probe(const char *buf, off_t len);
+int uImage_arm64_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int uImage_arm64_load(int argc, char **argv, const char *buf, off_t len,
 		      struct kexec_info *info);
 void uImage_arm64_usage(void);
 
-int zImage_arm64_probe(const char *kernel_buf, off_t kernel_size);
+int zImage_arm64_probe(const char *kernel_buf, off_t kernel_size,
+		       struct kexec_info *info);
+
 int zImage_arm64_load(int argc, char **argv, const char *kernel_buf,
 	off_t kernel_size, struct kexec_info *info);
 void zImage_arm64_usage(void);

--- a/kexec/arch/arm64/kexec-arm64.h
+++ b/kexec/arch/arm64/kexec-arm64.h
@@ -56,6 +56,10 @@ int zImage_arm64_load(int argc, char **argv, const char *kernel_buf,
 	off_t kernel_size, struct kexec_info *info);
 void zImage_arm64_usage(void);
 
+int pez_arm64_probe(const char *kern_fname, off_t kernel_size,
+			struct kexec_info *info);
+void pez_arm64_usage(void);
+
 
 extern off_t initrd_base;
 extern off_t initrd_size;

--- a/kexec/arch/arm64/kexec-elf-arm64.c
+++ b/kexec/arch/arm64/kexec-elf-arm64.c
@@ -16,12 +16,14 @@
 #include "kexec-elf.h"
 #include "kexec-syscall.h"
 
-int elf_arm64_probe(const char *kernel_buf, off_t kernel_size,
+int elf_arm64_probe(const char *kern_fname, off_t kernel_size,
 		    struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
+	char *kernel_buf;
 	int result;
 
+	kernel_buf = slurp_file(kern_fname, &kernel_size);
 	result = build_elf_exec_info(kernel_buf, kernel_size, &ehdr, 0);
 
 	if (result < 0) {
@@ -35,8 +37,11 @@ int elf_arm64_probe(const char *kernel_buf, off_t kernel_size,
 		goto on_exit;
 	}
 
+	info->kernel_fd = open(kern_fname, O_RDONLY);
+	info->kernel_buf = kernel_buf;
 	result = 0;
 on_exit:
+	free(kernel_buf);
 	free_elf_info(&ehdr);
 	return result;
 }

--- a/kexec/arch/arm64/kexec-elf-arm64.c
+++ b/kexec/arch/arm64/kexec-elf-arm64.c
@@ -16,7 +16,8 @@
 #include "kexec-elf.h"
 #include "kexec-syscall.h"
 
-int elf_arm64_probe(const char *kernel_buf, off_t kernel_size)
+int elf_arm64_probe(const char *kernel_buf, off_t kernel_size,
+		    struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/arm64/kexec-image-arm64.c
+++ b/kexec/arch/arm64/kexec-image-arm64.c
@@ -14,11 +14,13 @@
 #include "kexec-syscall.h"
 #include "arch/options.h"
 
-int image_arm64_probe(const char *kernel_buf, off_t kernel_size,
+int image_arm64_probe(const char *kern_fname, off_t kernel_size,
 		      struct kexec_info *info)
 {
 	const struct arm64_image_header *h;
+	char *kernel_buf;
 
+	kernel_buf = slurp_file(kern_fname, &kernel_size);
 	if (kernel_size < sizeof(struct arm64_image_header)) {
 		dbgprintf("%s: No arm64 image header.\n", __func__);
 		return -1;
@@ -30,6 +32,8 @@ int image_arm64_probe(const char *kernel_buf, off_t kernel_size,
 		dbgprintf("%s: Bad arm64 image header.\n", __func__);
 		return -1;
 	}
+	info->kernel_fd = open(kern_fname, O_RDONLY);
+	info->kernel_buf = kernel_buf;
 
 	return 0;
 }

--- a/kexec/arch/arm64/kexec-image-arm64.c
+++ b/kexec/arch/arm64/kexec-image-arm64.c
@@ -14,7 +14,8 @@
 #include "kexec-syscall.h"
 #include "arch/options.h"
 
-int image_arm64_probe(const char *kernel_buf, off_t kernel_size)
+int image_arm64_probe(const char *kernel_buf, off_t kernel_size,
+		      struct kexec_info *info)
 {
 	const struct arm64_image_header *h;
 

--- a/kexec/arch/arm64/kexec-uImage-arm64.c
+++ b/kexec/arch/arm64/kexec-uImage-arm64.c
@@ -9,7 +9,7 @@
 #include "../../kexec.h"
 #include "kexec-arm64.h"
 
-int uImage_arm64_probe(const char *buf, off_t len)
+int uImage_arm64_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	int ret;
 

--- a/kexec/arch/arm64/kexec-vmlinuz-arm64.c
+++ b/kexec/arch/arm64/kexec-vmlinuz-arm64.c
@@ -1,0 +1,101 @@
+/*
+ * ARM64 PE compressed Image (vmlinuz, ZBOOT) support.
+ *
+ * Several distros use 'make zinstall' rule inside
+ * 'arch/arm64/boot/Makefile' to install the arm64
+ * ZBOOT compressed file inside the boot destination
+ * directory (for e.g. /boot).
+ *
+ * Currently we cannot use kexec_file_load() to load vmlinuz
+ * PE images that self decompress.
+ *
+ * To support ZBOOT, we should:
+ * a). Copy the compressed contents of vmlinuz to a temporary file.
+ * b). Decompress (gunzip-decompress) the contents inside the
+ *     temporary file.
+ * c). Validate the resulting image and write it back to the
+ *     temporary file.
+ * d). Pass the 'fd' of the temporary file to the kernel space.
+ *
+ * Note this, module doesn't provide a _load() function instead
+ * relying on image_arm64_load() to load the resulting decompressed
+ * image.
+ *
+ * So basically the kernel space still gets a decompressed
+ * kernel image to load via kexec-tools.
+ */
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include "kexec-arm64.h"
+#include <kexec-pe-zboot.h>
+#include "arch/options.h"
+
+
+/* Returns:
+ * -1 : in case of error/invalid format (not a valid PE+compressed ZBOOT format.
+ */
+int pez_arm64_probe(const char *kern_fname, off_t kernel_size,
+		struct kexec_info *info)
+{
+	int ret = -1;
+	const struct arm64_image_header *h;
+	char *kernel_buf;
+
+	kernel_buf = slurp_file(kern_fname, &kernel_size);
+	if (!kernel_buf)
+		return -1;
+	h = (const struct arm64_image_header *)(kernel_buf);
+
+	dbgprintf("%s: PROBE.\n", __func__);
+	if (kernel_size < sizeof(struct arm64_image_header)) {
+		dbgprintf("%s: Not large enough to be a PE image.\n", __func__);
+		return -1;
+	}
+	if (!arm64_header_check_pe_sig(h)) {
+		dbgprintf("%s: Not an PE image.\n", __func__);
+		return -1;
+	}
+
+	if (kernel_size < sizeof(struct arm64_image_header) + h->pe_header) {
+		dbgprintf("%s: PE image offset larger than image.\n", __func__);
+		return -1;
+	}
+
+	if (memcmp(&kernel_buf[h->pe_header],
+		   arm64_pe_machtype, sizeof(arm64_pe_machtype))) {
+		dbgprintf("%s: PE header doesn't match machine type.\n", __func__);
+		return -1;
+	}
+
+	ret = pez_prepare(kernel_buf, kernel_size, info);
+
+	if (!ret) {
+	    /* validate the arm64 specific header */
+	    struct arm64_image_header hdr_check;
+	    if (read(info->kernel_fd, &hdr_check, sizeof(hdr_check)) != sizeof(hdr_check))
+		goto bad_header;
+
+	    lseek(info->kernel_fd, 0, SEEK_SET);
+
+	    if (!arm64_header_check_magic(&hdr_check)) {
+		dbgprintf("%s: Bad arm64 image header.\n", __func__);
+		goto bad_header;
+	    }
+	}
+
+	return ret;
+bad_header:
+	close(info->kernel_fd);
+	free(info->kernel_buf);
+	return -1;
+}
+
+void pez_arm64_usage(void)
+{
+	printf(
+"     An ARM64 vmlinuz, PE image of a compressed, little endian.\n"
+"     kernel, built with ZBOOT enabled.\n\n");
+}

--- a/kexec/arch/arm64/kexec-zImage-arm64.c
+++ b/kexec/arch/arm64/kexec-zImage-arm64.c
@@ -40,7 +40,8 @@
  * fd : File descriptor of the temp file containing the decompressed
  *      Image.
  */
-int zImage_arm64_probe(const char *kernel_buf, off_t kernel_size)
+int zImage_arm64_probe(const char *kernel_buf, off_t kernel_size,
+		       struct kexec_info *info)
 {
 	int ret = -1;
 	int fd = 0;

--- a/kexec/arch/arm64/kexec-zImage-arm64.c
+++ b/kexec/arch/arm64/kexec-zImage-arm64.c
@@ -56,8 +56,7 @@ int zImage_arm64_probe(const char *kernel_buf, off_t kernel_size,
 	}
 
 	if (!(fname = strdup(FILENAME_IMAGE))) {
-		dbgprintf("%s: Can't duplicate strings %s\n", __func__,
-				fname);
+		dbgprintf("%s: Can't duplicate strings\n", __func__);
 		return -1;
 	}
 
@@ -66,15 +65,6 @@ int zImage_arm64_probe(const char *kernel_buf, off_t kernel_size,
 				fname);
 		ret = -1;
 		goto fail_mkstemp;
-	}
-
-	kernel_uncompressed_buf =
-		(char *) calloc(kernel_size, sizeof(off_t));
-	if (!kernel_uncompressed_buf) {
-		dbgprintf("%s: Can't calloc %ld bytes\n",
-				__func__, kernel_size);
-		ret= -ENOMEM;
-		goto fail_calloc;
 	}
 
 	/* slurp in the input kernel */
@@ -129,7 +119,6 @@ int zImage_arm64_probe(const char *kernel_buf, off_t kernel_size,
 fail_bad_header:
 	free(kernel_uncompressed_buf);
 
-fail_calloc:
 	if (fd >= 0)
 		close(fd);
 

--- a/kexec/arch/cris/kexec-cris.h
+++ b/kexec/arch/cris/kexec-cris.h
@@ -1,7 +1,8 @@
 #ifndef KEXEC_CRIS_H
 #define KEXEC_CRIS_H
 
-int elf_cris_probe(const char *buf, off_t len);
+int elf_cris_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_cris_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_cris_usage(void);

--- a/kexec/arch/cris/kexec-elf-cris.c
+++ b/kexec/arch/cris/kexec-elf-cris.c
@@ -40,7 +40,7 @@
 #include <arch/options.h>
 #include "kexec-cris.h"
 
-int elf_cris_probe(const char *buf, off_t len)
+int elf_cris_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/hppa/kexec-elf-hppa.c
+++ b/kexec/arch/hppa/kexec-elf-hppa.c
@@ -30,7 +30,7 @@
 
 extern unsigned long phys_offset;
 
-int elf_hppa_probe(const char *buf, off_t len)
+int elf_hppa_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/hppa/kexec-hppa.h
+++ b/kexec/arch/hppa/kexec-hppa.h
@@ -1,7 +1,8 @@
 #ifndef KEXEC_HPPA_H
 #define KEXEC_HPPA_H
 
-int elf_hppa_probe(const char *buf, off_t len);
+int elf_hppa_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_hppa_load(int argc, char **argv, const char *buf, off_t len,
 		  struct kexec_info *info);
 void elf_hppa_usage(void);

--- a/kexec/arch/i386/kexec-beoboot-x86.c
+++ b/kexec/arch/i386/kexec-beoboot-x86.c
@@ -38,7 +38,7 @@
 #include "kexec-x86.h"
 #include <arch/options.h>
 
-int beoboot_probe(const char *buf, off_t len)
+int beoboot_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct beoboot_header bb_header;
 	const char *cmdline, *kernel;
@@ -57,7 +57,7 @@ int beoboot_probe(const char *buf, off_t len)
 	 */
 	cmdline = buf + sizeof(bb_header);
 	kernel  = cmdline + bb_header.cmdline_size;
-	result = bzImage_probe(kernel, bb_header.kernel_size);
+	result = bzImage_probe(kernel, bb_header.kernel_size, NULL);
 	
 	return result;
 }

--- a/kexec/arch/i386/kexec-bzImage.c
+++ b/kexec/arch/i386/kexec-bzImage.c
@@ -42,7 +42,7 @@
 static const int probe_debug = 0;
 int bzImage_support_efi_boot = 0;
 
-int bzImage_probe(const char *buf, off_t len)
+int bzImage_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	const struct x86_linux_header *header;
 	if ((uintmax_t)len < (uintmax_t)(2 * 512)) {

--- a/kexec/arch/i386/kexec-elf-x86.c
+++ b/kexec/arch/i386/kexec-elf-x86.c
@@ -96,7 +96,7 @@ int elf_x86_any_probe(const char *buf, off_t len, enum coretype arch)
 	return result;
 }
 
-int elf_x86_probe(const char *buf, off_t len) {
+int elf_x86_probe(const char *buf, off_t len, struct kexec_info *info) {
 	return elf_x86_any_probe(buf, len, CORE_TYPE_ELF32);
 }
 

--- a/kexec/arch/i386/kexec-mb2-x86.c
+++ b/kexec/arch/i386/kexec-mb2-x86.c
@@ -72,7 +72,8 @@ struct multiboot2_header_info {
 #define ALIGN_UP(addr, align) \
 	((addr + (typeof (addr)) align - 1) & ~((typeof (addr)) align - 1))
 
-int multiboot2_x86_probe(const char *buf, off_t buf_len)
+int multiboot2_x86_probe(const char *buf, off_t buf_len,
+			 struct kexec_info *info)
 /* Is it a good idea to try booting this file? */
 {
 	int i, len;
@@ -438,7 +439,7 @@ int multiboot2_x86_load(int argc, char **argv, const char *buf, off_t len,
 	uint64_t rel_min, rel_max;
 
 	/* Probe for the MB header if it's not already found */
-	if (mbh == NULL && multiboot_x86_probe(buf, len) != 1)
+	if (mbh == NULL && multiboot_x86_probe(buf, len, NULL) != 1)
 	{
 		fprintf(stderr, "Cannot find a loadable multiboot2 header.\n");
 		return -1;

--- a/kexec/arch/i386/kexec-multiboot-x86.c
+++ b/kexec/arch/i386/kexec-multiboot-x86.c
@@ -69,7 +69,8 @@ static off_t mbh_offset = 0;
 #define MIN(_x,_y) (((_x)<=(_y))?(_x):(_y))
 
 
-int multiboot_x86_probe(const char *buf, off_t buf_len)
+int multiboot_x86_probe(const char *buf, off_t buf_len,
+			struct kexec_info *info)
 /* Is it a good idea to try booting this file? */
 {
 	int i, len;
@@ -119,7 +120,7 @@ int multiboot_x86_probe(const char *buf, off_t buf_len)
 				return -1;
 			}
 		} else {
-			if ((i=elf_x86_probe(buf, buf_len)) < 0)
+			if ((i=elf_x86_probe(buf, buf_len, NULL)) < 0)
 				return i;
 		}
 		if (mbh->flags & MULTIBOOT_UNSUPPORTED) {
@@ -252,7 +253,7 @@ int multiboot_x86_load(int argc, char **argv, const char *buf, off_t len,
 	static const char short_options[] = KEXEC_ARCH_OPT_STR "";
 	
 	/* Probe for the MB header if it's not already found */
-	if (mbh == NULL && multiboot_x86_probe(buf, len) != 1) {
+	if (mbh == NULL && multiboot_x86_probe(buf, len, NULL) != 1) {
 		fprintf(stderr, "Cannot find a loadable multiboot header.\n");
 		return -1;
 	}

--- a/kexec/arch/i386/kexec-nbi.c
+++ b/kexec/arch/i386/kexec-nbi.c
@@ -68,7 +68,7 @@ struct imgheader
 
 static const int probe_debug = 0;
 
-int nbi_probe(const char *buf, off_t len)
+int nbi_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct imgheader hdr;
 	struct segheader seg;

--- a/kexec/arch/i386/kexec-x86.h
+++ b/kexec/arch/i386/kexec-x86.h
@@ -55,7 +55,8 @@ struct arch_options_t {
 	uint8_t		reuse_video_type;
 };
 
-int multiboot_x86_probe(const char *buf, off_t len);
+int multiboot_x86_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int multiboot_x86_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void multiboot_x86_usage(void);
@@ -63,15 +64,19 @@ void multiboot_x86_usage(void);
 int multiboot2_x86_load(int argc, char **argv, const char *buf, off_t len,
 			struct kexec_info *info);
 void multiboot2_x86_usage(void);
-int multiboot2_x86_probe(const char *buf, off_t buf_len);
+int multiboot2_x86_probe(const char *buf, off_t buf_len,
+			 struct kexec_info *info);
 
-int elf_x86_probe(const char *buf, off_t len);
+
+int elf_x86_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_x86_any_probe(const char *buf, off_t len, enum coretype arch);
 int elf_x86_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_x86_usage(void);
 
-int bzImage_probe(const char *buf, off_t len);
+int bzImage_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int bzImage_load(int argc, char **argv, const char *buf, off_t len, 
 	struct kexec_info *info);
 void bzImage_usage(void);
@@ -82,12 +87,14 @@ int do_bzImage_load(struct kexec_info *info,
 	const char *dtb, off_t dtb_len,
 	int real_mode_entry);
 
-int beoboot_probe(const char *buf, off_t len);
+int beoboot_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int beoboot_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void beoboot_usage(void);
 
-int nbi_probe(const char *buf, off_t len);
+int nbi_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int nbi_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void nbi_usage(void);

--- a/kexec/arch/ia64/kexec-elf-ia64.c
+++ b/kexec/arch/ia64/kexec-elf-ia64.c
@@ -53,7 +53,7 @@ extern unsigned long saved_efi_memmap_size;
  *
  * Make sure that the file image has a reasonable chance of working.
  */
-int elf_ia64_probe(const char *buf, off_t len)
+int elf_ia64_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/ia64/kexec-ia64.h
+++ b/kexec/arch/ia64/kexec-ia64.h
@@ -2,7 +2,8 @@
 #define KEXEC_IA64_H
 
 extern int max_memory_ranges;
-int elf_ia64_probe(const char *buf, off_t len);
+int elf_ia64_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_ia64_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_ia64_usage(void);

--- a/kexec/arch/loongarch/kexec-elf-loongarch.c
+++ b/kexec/arch/loongarch/kexec-elf-loongarch.c
@@ -23,7 +23,8 @@
 
 off_t initrd_base, initrd_size;
 
-int elf_loongarch_probe(const char *kernel_buf, off_t kernel_size)
+int elf_loongarch_probe(const char *kernel_buf, off_t kernel_size,
+			struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/loongarch/kexec-loongarch.h
+++ b/kexec/arch/loongarch/kexec-loongarch.h
@@ -18,12 +18,15 @@
 #define KiB(x) ((x) * 1024UL)
 #define MiB(x) (KiB(x) * 1024UL)
 
-int elf_loongarch_probe(const char *kernel_buf, off_t kernel_size);
+int elf_loongarch_probe(const char *kernel_buf, off_t kernel_size,
+			struct kexec_info *info);
+
 int elf_loongarch_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_loongarch_usage(void);
 
-int pei_loongarch_probe(const char *buf, off_t len);
+int pei_loongarch_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int pei_loongarch_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void pei_loongarch_usage(void);

--- a/kexec/arch/loongarch/kexec-pei-loongarch.c
+++ b/kexec/arch/loongarch/kexec-pei-loongarch.c
@@ -24,7 +24,8 @@
 #include "kexec-loongarch.h"
 #include "arch/options.h"
 
-int pei_loongarch_probe(const char *kernel_buf, off_t kernel_size)
+int pei_loongarch_probe(const char *kernel_buf, off_t kernel_size,
+			struct kexec_info *info)
 {
 	const struct loongarch_image_header *h;
 

--- a/kexec/arch/m68k/kexec-elf-m68k.c
+++ b/kexec/arch/m68k/kexec-elf-m68k.c
@@ -33,7 +33,7 @@
 #define PAGE_SIZE	4 KiB
 
 
-int elf_m68k_probe(const char *buf, off_t len)
+int elf_m68k_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/m68k/kexec-m68k.h
+++ b/kexec/arch/m68k/kexec-m68k.h
@@ -1,7 +1,8 @@
 #ifndef KEXEC_M68K_H
 #define KEXEC_M68K_H
 
-int elf_m68k_probe(const char *buf, off_t len);
+int elf_m68k_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_m68k_load(int argc, char **argv, const char *buf, off_t len,
 		  struct kexec_info *info);
 void elf_m68k_usage(void);

--- a/kexec/arch/mips/kexec-elf-mips.c
+++ b/kexec/arch/mips/kexec-elf-mips.c
@@ -92,7 +92,7 @@ static int patch_initrd_info(char *cmdline, unsigned long base,
 	return 0;
 }
 
-int elf_mips_probe(const char *buf, off_t len)
+int elf_mips_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/mips/kexec-mips.h
+++ b/kexec/arch/mips/kexec-mips.h
@@ -12,7 +12,8 @@
 #define CORE_TYPE_ELF32 1
 #define CORE_TYPE_ELF64 2
 
-int elf_mips_probe(const char *buf, off_t len);
+int elf_mips_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_mips_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_mips_usage(void);

--- a/kexec/arch/ppc/kexec-dol-ppc.c
+++ b/kexec/arch/ppc/kexec-dol-ppc.c
@@ -234,7 +234,7 @@ void fix_dol_segments_overlaps(dol_segment * seg, int max_segs)
 	}
 }
 
-int dol_ppc_probe(const char *buf, off_t dol_length)
+int dol_ppc_probe(const char *buf, off_t dol_length, struct kexec_info *info)
 {
 	dol_header header, *h;
 	int i, valid = 0;

--- a/kexec/arch/ppc/kexec-elf-ppc.c
+++ b/kexec/arch/ppc/kexec-elf-ppc.c
@@ -73,7 +73,7 @@ static struct boot_notes {
 };
 #endif
 
-int elf_ppc_probe(const char *buf, off_t len)
+int elf_ppc_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 
 	struct mem_ehdr ehdr;

--- a/kexec/arch/ppc/kexec-ppc.h
+++ b/kexec/arch/ppc/kexec-ppc.h
@@ -25,17 +25,20 @@ extern struct {
 
 #define SIZE_16M	(16*1024*1024UL)
 
-int elf_ppc_probe(const char *buf, off_t len);
+int elf_ppc_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_ppc_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_ppc_usage(void);
 
-int uImage_ppc_probe(const char *buf, off_t len);
+int uImage_ppc_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int uImage_ppc_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void uImage_ppc_usage(void);
 
-int dol_ppc_probe(const char *buf, off_t len);
+int dol_ppc_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int dol_ppc_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void dol_ppc_usage(void);

--- a/kexec/arch/ppc/kexec-uImage-ppc.c
+++ b/kexec/arch/ppc/kexec-uImage-ppc.c
@@ -76,7 +76,7 @@ char *slurp_ramdisk_ppc(const char *filename, off_t *r_size)
 	return buf;
 }
 	
-int uImage_ppc_probe(const char *buf, off_t len)
+int uImage_ppc_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	return uImage_probe_kernel(buf, len, IH_ARCH_PPC);
 }

--- a/kexec/arch/ppc64/kexec-elf-ppc64.c
+++ b/kexec/arch/ppc64/kexec-elf-ppc64.c
@@ -45,7 +45,7 @@ uint64_t initrd_base, initrd_size;
 unsigned char reuse_initrd = 0;
 const char *ramdisk;
 
-int elf_ppc64_probe(const char *buf, off_t len)
+int elf_ppc64_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/ppc64/kexec-ppc64.h
+++ b/kexec/arch/ppc64/kexec-ppc64.h
@@ -19,7 +19,8 @@ extern int get_devtree_value(const char *fname, unsigned long long *pvalue);
 
 int setup_memory_ranges(unsigned long kexec_flags);
 
-int elf_ppc64_probe(const char *buf, off_t len);
+int elf_ppc64_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_ppc64_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_ppc64_usage(void);

--- a/kexec/arch/s390/kexec-image.c
+++ b/kexec/arch/s390/kexec-image.c
@@ -216,7 +216,7 @@ out:
 }
 
 int 
-image_s390_probe(const char *UNUSED(kernel_buf), off_t UNUSED(kernel_size))
+image_s390_probe(const char *UNUSED(kernel_buf), off_t UNUSED(kernel_size), struct kexec_info *UNUSED(info))
 {
 	/*
 	 * Can't reliably tell if an image is valid,

--- a/kexec/arch/sh/kexec-elf-sh.c
+++ b/kexec/arch/sh/kexec-elf-sh.c
@@ -40,7 +40,7 @@
 #include "crashdump-sh.h"
 #include "kexec-sh.h"
 
-int elf_sh_probe(const char *buf, off_t len)
+int elf_sh_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	struct mem_ehdr ehdr;
 	int result;

--- a/kexec/arch/sh/kexec-netbsd-sh.c
+++ b/kexec/arch/sh/kexec-netbsd-sh.c
@@ -33,7 +33,7 @@ extern const unsigned char netbsd_booter[];
  *
  * Make sure that the file image has a reasonable chance of working.
  */
-int netbsd_sh_probe(const char *buf, off_t UNUSED(len))
+int netbsd_sh_probe(const char *buf, off_t UNUSED(len), struct kexec_info *UNUSED(info))
 {
 	Elf32_Ehdr *ehdr;
 

--- a/kexec/arch/sh/kexec-sh.h
+++ b/kexec/arch/sh/kexec-sh.h
@@ -3,21 +3,25 @@
 
 #define COMMAND_LINE_SIZE 2048
 
-int uImage_sh_probe(const char *buf, off_t len);
+int uImage_sh_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int uImage_sh_load(int argc, char **argv, const char *buf, off_t len,
 		        struct kexec_info *info);
 
-int zImage_sh_probe(const char *buf, off_t len);
+int zImage_sh_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int zImage_sh_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void zImage_sh_usage(void);
 
-int elf_sh_probe(const char *buf, off_t len);
+int elf_sh_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_sh_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_sh_usage(void);
 
-int netbsd_sh_probe(const char *buf, off_t len);
+int netbsd_sh_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int netbsd_sh_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void netbsd_sh_usage(void);

--- a/kexec/arch/sh/kexec-uImage-sh.c
+++ b/kexec/arch/sh/kexec-uImage-sh.c
@@ -11,7 +11,7 @@
 #include "../../kexec.h"
 #include "kexec-sh.h"
 
-int uImage_sh_probe(const char *buf, off_t len)
+int uImage_sh_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	return uImage_probe_kernel(buf, len, IH_ARCH_SH);
 }

--- a/kexec/arch/sh/kexec-zImage-sh.c
+++ b/kexec/arch/sh/kexec-zImage-sh.c
@@ -51,7 +51,7 @@ static unsigned long zImage_head32(const char *buf, int offs)
  *
  * Make sure that the file image has a reasonable chance of working.
  */
-int zImage_sh_probe(const char *buf, off_t UNUSED(len))
+int zImage_sh_probe(const char *buf, off_t UNUSED(len), struct kexec_info *UNUSED(info))
 {
 	if (memcmp(&buf[0x202], "HdrS", 4) != 0)
 	        return -1;

--- a/kexec/arch/x86_64/kexec-bzImage64.c
+++ b/kexec/arch/x86_64/kexec-bzImage64.c
@@ -43,7 +43,7 @@
 
 static const int probe_debug = 0;
 
-int bzImage64_probe(const char *buf, off_t len)
+int bzImage64_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	const struct x86_linux_header *header;
 

--- a/kexec/arch/x86_64/kexec-elf-x86_64.c
+++ b/kexec/arch/x86_64/kexec-elf-x86_64.c
@@ -41,7 +41,7 @@
 #include "../i386/crashdump-x86.h"
 #include <arch/options.h>
 
-int elf_x86_64_probe(const char *buf, off_t len)
+int elf_x86_64_probe(const char *buf, off_t len, struct kexec_info *info)
 {
 	return elf_x86_any_probe(buf, len, CORE_TYPE_ELF64);
 }

--- a/kexec/arch/x86_64/kexec-x86_64.h
+++ b/kexec/arch/x86_64/kexec-x86_64.h
@@ -23,12 +23,14 @@ struct entry64_regs {
 	uint64_t rip;
 };
 
-int elf_x86_64_probe(const char *buf, off_t len);
+int elf_x86_64_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int elf_x86_64_load(int argc, char **argv, const char *buf, off_t len,
 	struct kexec_info *info);
 void elf_x86_64_usage(void);
 
-int bzImage64_probe(const char *buf, off_t len);
+int bzImage64_probe(const char *buf, off_t len, struct kexec_info *info);
+
 int bzImage64_load(int argc, char **argv, const char *buf, off_t len,
 			struct kexec_info *info);
 void bzImage64_usage(void);
@@ -36,6 +38,8 @@ void bzImage64_usage(void);
 int multiboot2_x86_load(int argc, char **argv, const char *buf, off_t len,
 			struct kexec_info *info);
 void multiboot2_x86_usage(void);
-int multiboot2_x86_probe(const char *buf, off_t buf_len);
+int multiboot2_x86_probe(const char *buf, off_t buf_len,
+			 struct kexec_info *info);
+
 
 #endif /* KEXEC_X86_64_H */

--- a/kexec/kexec-pe-zboot.c
+++ b/kexec/kexec-pe-zboot.c
@@ -1,0 +1,134 @@
+/*
+ * Generic PE compressed Image (vmlinuz, ZBOOT) support.
+ *
+ * Several distros use 'make zinstall' with CONFIG_ZBOOT
+ * enabled to create UEFI PE images that contain
+ * a decompressor and a compressed kernel image.
+ *
+ * Currently we cannot use kexec_file_load() to load vmlinuz
+ * PE images that self decompress.
+ *
+ * To support ZBOOT, we should:
+ * a). Copy the compressed contents of vmlinuz to a temporary file.
+ * b). Decompress (gunzip-decompress) the contents inside the
+ *     temporary file.
+ * c). Validate the resulting image and write it back to the
+ *     temporary file.
+ * d). Pass the 'fd' of the temporary file to the kernel space.
+ *
+ * This module contains the arch independent code for the above,
+ * arch specific PE and image checks should wrap calls
+ * to functions in this module.
+ */
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "kexec.h"
+#include <kexec-pe-zboot.h>
+
+#define FILENAME_IMAGE		"/tmp/ImageXXXXXX"
+
+/*
+ * Returns -1 : in case of error/invalid format (not a valid PE+compressed ZBOOT format.
+ *
+ * crude_buf: the content, which is read from the kernel file without any processing
+ */
+int pez_prepare(const char *crude_buf, off_t kernel_size, struct kexec_info *info)
+{
+	int ret = -1;
+	int fd = 0;
+	int kernel_fd = 0;
+	char *fname = NULL;
+	char *kernel_uncompressed_buf = NULL;
+	off_t decompressed_size = 0;
+	const struct linux_pe_zboot_header *z;
+
+	z = (const struct linux_pe_zboot_header *)(crude_buf);
+
+	if (memcmp(&z->image_type, "zimg", sizeof(z->image_type))) {
+		dbgprintf("%s: PE doesn't contain a compressed kernel.\n", __func__);
+		return -1;
+	}
+
+	/*
+	 * At the moment its possible to create images with more compression
+	 * algorithms than are supported here, error out if we detect that.
+	 */
+	if (memcmp(&z->compress_type, "gzip", 4) &&
+	    memcmp(&z->compress_type, "lzma", 4)) {
+		dbgprintf("%s: kexec can only decompress gziped and lzma images.\n", __func__);
+		return -1;
+	}
+
+	if (kernel_size < z->payload_offset + z->payload_size) {
+		dbgprintf("%s: PE too small to contain complete payload.\n", __func__);
+		return -1;
+	}
+
+	if (!(fname = strdup(FILENAME_IMAGE))) {
+		dbgprintf("%s: Can't duplicate strings\n", __func__);
+		return -1;
+	}
+
+	if ((fd = mkstemp(fname)) < 0) {
+		dbgprintf("%s: Can't open file %s\n", __func__,	fname);
+		ret = -1;
+		goto fail_mkstemp;
+	}
+
+	if (write(fd, &crude_buf[z->payload_offset],
+		  z->payload_size) != z->payload_size) {
+		dbgprintf("%s: Can't write the compressed file %s\n",
+				__func__, fname);
+		ret = -1;
+		goto fail_write;
+	}
+
+	kernel_uncompressed_buf = slurp_decompress_file(fname,
+							&decompressed_size);
+
+	dbgprintf("%s: decompressed size %ld\n", __func__, decompressed_size);
+
+	lseek(fd, 0, SEEK_SET);
+
+	if (write(fd,  kernel_uncompressed_buf,
+		  decompressed_size) != decompressed_size) {
+		dbgprintf("%s: Can't write the decompressed file %s\n",
+				__func__, fname);
+		ret = -1;
+		goto fail_bad_header;
+	}
+
+	kernel_fd = open(fname, O_RDONLY);
+	if (kernel_fd == -1) {
+		dbgprintf("%s: Failed to open file %s\n",
+				__func__, fname);
+		ret = -1;
+		goto fail_bad_header;
+	}
+
+	dbgprintf("%s: ", __func__);
+
+	info->kernel_fd = kernel_fd;
+	info->kernel_buf = kernel_uncompressed_buf;
+	ret = 0;
+	goto fail_write;
+
+fail_bad_header:
+	free(kernel_uncompressed_buf);
+
+fail_write:
+	if (fd >= 0)
+		close(fd);
+
+	unlink(fname);
+
+fail_mkstemp:
+	free(fname);
+
+	return ret;
+}

--- a/kexec/kexec.c
+++ b/kexec/kexec.c
@@ -742,13 +742,13 @@ static int my_load(const char *type, int fileind, int argc, char **argv,
 			return -1;
 		} else {
 			/* make sure our file is really of that type */
-			if (file_type[i].probe(kernel_buf, kernel_size) < 0)
+			if (file_type[i].probe(kernel_buf, kernel_size, NULL) < 0)
 				guess_only = 1;
 		}
 	}
 	if (!type || guess_only) {
 		for (i = 0; i < file_types; i++) {
-			if (file_type[i].probe(kernel_buf, kernel_size) == 0)
+			if (file_type[i].probe(kernel_buf, kernel_size, NULL) == 0)
 				break;
 		}
 		if (i == file_types) {
@@ -1304,15 +1304,15 @@ static int do_kexec_file_load(int fileind, int argc, char **argv,
 #ifdef __aarch64__
 		/* handle Image.gz like cases */
 		if (is_zlib_file(kernel, &kernel_size)) {
-			if ((ret = file_type[i].probe(kernel, kernel_size)) >= 0) {
+			if ((ret = file_type[i].probe(kernel, kernel_size, NULL)) >= 0) {
 				kernel_fd = ret;
 				break;
 			}
 		} else
-			if (file_type[i].probe(kernel_buf, kernel_size) >= 0)
+			if (file_type[i].probe(kernel_buf, kernel_size, NULL) >= 0)
 				break;
 #else
-		if (file_type[i].probe(kernel_buf, kernel_size) >= 0)
+		if (file_type[i].probe(kernel_buf, kernel_size, NULL) >= 0)
 			break;
 #endif
 	}

--- a/kexec/kexec.h
+++ b/kexec/kexec.h
@@ -164,7 +164,9 @@ struct kexec_info {
 	unsigned long file_mode :1;
 
 	/* Filled by kernel image processing code */
+	int kernel_fd;
 	int initrd_fd;
+	char *kernel_buf;
 	char *command_line;
 	int command_line_len;
 

--- a/kexec/kexec.h
+++ b/kexec/kexec.h
@@ -191,7 +191,7 @@ unsigned long locate_hole(struct kexec_info *info,
 	unsigned long hole_min, unsigned long hole_max,
 	int hole_end);
 
-typedef int (probe_t)(const char *kernel_buf, off_t kernel_size);
+typedef int (probe_t)(const char *kernel, off_t kernel_size, struct kexec_info *info);
 typedef int (load_t )(int argc, char **argv,
 	const char *kernel_buf, off_t kernel_size, 
 	struct kexec_info *info);


### PR DESCRIPTION
As more complicated capsule kernel format occurs like zboot, where the
compressed kernel is stored as a payload. The straight forward
decompression can not meet the demand.

As the first step, on aarch64, reading in the kernel file in a probe
method and decide how to unfold the content by the method itself.

The new designed probe interface returns two factors:
1. the parsed kernel_buf should be returned so that it can be used by
the image load method later.
2. the final fd passed to sys_kexec_file_load, since aarch64 kernel can
only work with Image format, the outer payload should be stripped and a
temporary file of Image should be created.

* Things left to do on arches besides aarch64 *
After substitution, although each probe mehod seems to have the same
prototype, they have differenct purpose on the first argument.
On aarch64, the argument is used to pass the kernel file name, while on
the other arches, it is used to passs the decompressed kernel.

This can be cured by scattering out the logic of reading the kernel file
into each probe. (This should be done by coccinelle. But let us keep a
small step for the time being)

v2 -> v3:
Fix some missing replacement by Coccinelle in [1/6], due to UNUSED() macro

v1 -> v2:
take in Jeremy's patches to implement zboot format support
use coccinelle and sed to substitue the image probe method prototype.
