### PR TITLE
misc fixes

### DIFF
--- a/kexec/arch/i386/kexec-x86-common.c
+++ b/kexec/arch/i386/kexec-x86-common.c
@@ -317,7 +317,8 @@ int efi_map_added( void ) {
 	char buf[512];
 	FILE *fp = fopen( "/proc/cmdline", "r" );
 	if( fp ) {
-		fgets( buf, 512, fp );
+		if (fgets( buf, 512, fp ) == NULL)
+			return 0;
 		fclose( fp );
 		return strstr( buf, "add_efi_memmap" ) != NULL;
 	} else {

--- a/kexec/arch/i386/x86-linux-setup.c
+++ b/kexec/arch/i386/x86-linux-setup.c
@@ -510,7 +510,8 @@ int get_bootparam(void *buf, off_t offset, size_t size)
 		return 1;
 	if (lseek(data_file, offset, SEEK_SET) < 0)
 		goto close;
-	read(data_file, buf, size);
+	if (read(data_file, buf, size) == -1)
+		return 1;
 close:
 	close(data_file);
 	return 0;

--- a/kexec/kexec-pe-zboot.c
+++ b/kexec/kexec-pe-zboot.c
@@ -112,7 +112,10 @@ int pez_prepare(const char *crude_buf, off_t buf_sz, int *kernel_fd,
 		/* If signed, the Attribute Certificate Table is always at the end of the PE file */
 		if (dir->certs.virtual_address != 0 && dir->certs.size != 0) {
 			original_file_sz = dir->certs.virtual_address + dir->certs.size;
-			ftruncate(fd, 0);
+			if (ftruncate(fd, 0)) {
+				dbgprintf("%s: Can't truncate file %s\n", __func__, fname);
+				goto fail_bad_header;
+			}
 		}
 	}
 

--- a/kexec/zstd.c
+++ b/kexec/zstd.c
@@ -21,6 +21,7 @@
  * Reimplementation of private function available if zstd is
  * statically linked. Remove when it becomes public.
  */
+__attribute__((weak))
 unsigned ZSTD_isFrame(const void* buffer, size_t size)
 {
 	uint8_t *buf = (uint8_t *)buffer;


### PR DESCRIPTION
commit d4ce855c0d3234610addd46732eb4667ff9ab9ad
Author: Nicholas Sielicki <github@opensource.nslick.com>
Date:   Sun Jun 22 04:49:48 2025 -0700

    misc: fix nodiscard warnings

    check return codes on these to satisfy newer gcc versions

    Signed-off-by: Nicholas Sielicki <github@opensource.nslick.com>

commit fa9149c1cce36c7cec5949ee06e0c48a25715cc1
Author: Nicholas Sielicki <github@opensource.nslick.com>
Date:   Sun Jun 22 04:47:47 2025 -0700

    kexec: zstd: fix static build

    weakly link the local ZSTD_isFrame reimplementation so as to not collide
    with the real symbol under static builds.

    Signed-off-by: Nicholas Sielicki <github@opensource.nslick.com>