### PR TITLE
Fix multiple build errors on 32-bit PowerPC

### DIFF
--- a/kexec/arch/ppc/fs2dt.c
+++ b/kexec/arch/ppc/fs2dt.c
@@ -292,7 +292,8 @@ static void putprops(char *fn, struct dirent **nlist, int numlist)
  * Compare function used to sort the device-tree directories
  * This function will be passed to scandir.
  */
-static int comparefunc(const void *dentry1, const void *dentry2)
+static int comparefunc(const struct dirent **dentry1,
+		       const struct dirent **dentry2)
 {
 	char *str1 = (*(struct dirent **)dentry1)->d_name;
 	char *str2 = (*(struct dirent **)dentry2)->d_name;

--- a/kexec/arch/ppc/kexec-ppc.c
+++ b/kexec/arch/ppc/kexec-ppc.c
@@ -91,7 +91,7 @@ int read_memory_region_limits(int fd, unsigned long long *start,
 				unsigned long long *end)
 {
 	char buf[MAXBYTES];
-	unsigned long *p;
+	unsigned long long *p;
 	unsigned long nbytes = dt_address_cells + dt_size_cells;
 
 	if (lseek(fd, 0, SEEK_SET) == -1) {
@@ -103,7 +103,7 @@ int read_memory_region_limits(int fd, unsigned long long *start,
 		return -1;
 	}
 
-	p = (unsigned long*)buf;
+	p = (unsigned long long*)buf;
 	if (dt_address_cells == sizeof(unsigned long)) {
 		*start = p[0];
 		p++;


### PR DESCRIPTION
These changes fixes multiple build errors on 32-bit PowerPC as they occur on more modern GCC versions.